### PR TITLE
[FIXED JENKINS-25201] - Make console sections non-floating if the content exceed the window height

### DIFF
--- a/src/main/resources/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote/script.js
+++ b/src/main/resources/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote/script.js
@@ -59,7 +59,7 @@ function doToggle(o)
             if (offsets.y - window.scrollY <= 5 && floatSection.offsetHeight <= window.innerHeight) {
                 if (floatSection.className != "scrollDetached") {
                     floatSection.className = "scrollDetached";
-                    floatSection.style.width = d.offsetWidth;
+                    floatSection.style.width = d.offsetWidth + "px";
                 }
 
                 floatSection.style["left"] = -window.scrollX + offsets.x + "px";

--- a/src/main/resources/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote/script.js
+++ b/src/main/resources/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote/script.js
@@ -54,7 +54,9 @@ function doToggle(o)
             var offsets = getoffsets(d);
             var floatSection = d.childNodes[0];
 
-            if (offsets.y - window.scrollY <= 5) {
+            // if the height of the floatSection exceeds the window then keep it attached
+            // detached would make some items inaccessible
+            if (offsets.y - window.scrollY <= 5 && floatSection.offsetHeight <= window.innerHeight) {
                 if (floatSection.className != "scrollDetached") {
                     floatSection.className = "scrollDetached";
                     floatSection.style.width = d.offsetWidth;


### PR DESCRIPTION
Currently the box uses `position: fixed` when scrolling down. But if the content of the box exceeds the window height some sections are not accessible.

This patch checks the height of the box and compares it to the height of the window. If it does not fit in the window it sticks to `position: static` instead of `fixed`.

This addresses https://issues.jenkins-ci.org/browse/JENKINS-25201
