### PR TITLE
Change `Util.xmlEscape` to `Util.escape`

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionAnnotator.java
+++ b/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionAnnotator.java
@@ -92,7 +92,7 @@ public class CollapsingSectionAnnotator extends ConsoleAnnotator<Object> {
     
     private void pushSection(MarkupText text, Matcher m, SectionDefinition section) {
         numberingStack.peek().increment();  
-        text.addMarkup(0, "<div class=\"collapseHeader\">" + getCurrentLevelPrefix() + Util.escape(section.getSectionDisplayName(m)) + "<div class=\"collapseAction\"><p onClick=\"doToggle(this)\">Hide Details</p></div></div><div class=\"expanded\">");        
+        text.addMarkup(0, "<div class=\"collapseHeader\">" + getCurrentLevelPrefix() + Util.xmlEscape(section.getSectionDisplayName(m)) + "<div class=\"collapseAction\"><p onClick=\"doToggle(this)\">Hide Details</p></div></div><div class=\"expanded\">");        
         numberingStack.add(new StackLevel());
         currentSections.push(section);
     }


### PR DESCRIPTION
This is the best way to escape text that will be displayed as XML or HTML. So when I want my section to be called "Copying to \\server\d$\dir", it will no longer show as "Copying to \serverd$dir" in the plugin's nav menu.
