### PR TITLE
NPE in CollapsingSectionsConfiguration.getSectionDefinitions

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionsConfiguration.java
+++ b/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionsConfiguration.java
@@ -37,7 +37,7 @@ public class CollapsingSectionsConfiguration implements Serializable {
     private final boolean numberingEnabled;
    
     public CollapsingSectionsConfiguration(CollapsingSectionNote[] sections, boolean numberingEnabled) {
-        this.sections = sections;
+        this.sections = sections != null ? sections : new CollapsingSectionNote[]{} ;
         this.numberingEnabled = numberingEnabled;
     }
 


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-30690
I changed constructor to load an empty array if sections null is passed.

@reviewbybees
