### PR TITLE
Migrate to the new Parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,30 +98,30 @@ THE SOFTWARE.
             <plugins>
                 <plugin>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>2.2</version>
+                    <version>2.9</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>javancss-maven-plugin</artifactId>
-                    <version>2.0</version>
+                    <version>2.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jxr-plugin</artifactId>
-                    <version>2.2</version>
+                    <version>2.5</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-pmd-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.6</version>
                 </plugin>
                 <plugin>
                     <groupId>com.atlassian.maven.plugins</groupId>
                     <artifactId>maven-clover2-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>4.0.6</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>jdepend-maven-plugin</artifactId>
-                    <version>2.0-beta-2</version>
+                    <version>2.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>       

--- a/pom.xml
+++ b/pom.xml
@@ -64,13 +64,10 @@ THE SOFTWARE.
         <developer>
             <id>oleg_nenashev</id>
             <name>Oleg Nenashev</name>
-            <email>nenashev@synopsys.com; o.v.nenashev@gmail.com</email>
-            <organizationUrl>http://www.synopsys.com</organizationUrl>
-            <organization>Synopsys Inc.</organization>              			
+            <email>o.v.nenashev@gmail.com</email>           			
             <roles>
                 <role>maintainer</role>
             </roles>
-            <timezone>+4</timezone>
         </developer>
     </developers>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,15 +26,22 @@ THE SOFTWARE.
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.jvnet.hudson.plugins</groupId>
+        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.381</version>
-        <relativePath>../pom.xml</relativePath>
+        <version>2.9</version>
     </parent>
 
     <artifactId>collapsing-console-sections</artifactId>
     <version>1.4.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
+    
+    <properties>
+        <jenkins.version>1.532.3</jenkins.version>
+        <jenkins-test-harness.version>1.532.3</jenkins-test-harness.version>
+        <java.level>6</java.level>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.license>mit</project.license>
+    </properties>
 
     <name>Jenkins Collapsing Console Sections Plugin</name>
     <description>Annotations to collapse sections of the build console</description>
@@ -69,27 +76,6 @@ THE SOFTWARE.
 
     <build>
         <plugins>
-            <!--Validate Java version (1.7 isn't supported)-->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.2</version>
-                <executions>
-                    <execution>
-                        <id>enforce-versions</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireJavaVersion>
-                                    <version>[1.6,1.7)</version>
-                                </requireJavaVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.9</version>
+        <version>2.10</version>
     </parent>
 
     <artifactId>collapsing-console-sections</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -95,24 +95,8 @@ THE SOFTWARE.
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.4.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.3.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.7</version>
-                </plugin>
-                <plugin>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
                     <version>2.2</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>2.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -126,10 +110,6 @@ THE SOFTWARE.
                 <plugin>
                     <artifactId>maven-pmd-plugin</artifactId>
                     <version>2.5</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>2.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>com.atlassian.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,12 +87,6 @@ THE SOFTWARE.
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
-            <plugin>
-                <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <goals>deploy</goals>
-                </configuration>
-            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
@@ -126,20 +120,6 @@ THE SOFTWARE.
             </plugins>
         </pluginManagement>       
     </build>
-
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
     
     <scm>
         <connection>scm:git:ssh://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
@@ -147,12 +127,6 @@ THE SOFTWARE.
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     </scm>
     
-    <distributionManagement>
-        <repository>
-            <id>maven.jenkins-ci.org</id>
-            <url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
-        </repository>
-    </distributionManagement>
 </project>  
   
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,10 @@ THE SOFTWARE.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.${java.level}</source>
+                    <target>1.${java.level}</target>
+                    <testSource>1.${java.level.test}</testSource>
+                    <testTarget>1.${java.level.test}</testTarget>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                     <optimize>true</optimize>

--- a/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionsConfiguration.java
+++ b/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionsConfiguration.java
@@ -26,6 +26,7 @@ package org.jvnet.hudson.plugins.collapsingconsolesections;
 import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 /**
  * Provides a serializable instance of collapsing sections global configs. 
@@ -37,7 +38,7 @@ public class CollapsingSectionsConfiguration implements Serializable {
     private final boolean numberingEnabled;
    
     public CollapsingSectionsConfiguration(CollapsingSectionNote[] sections, boolean numberingEnabled) {
-        this.sections = sections;
+        this.sections = sections != null ? Arrays.copyOf(sections, sections.length) : new CollapsingSectionNote[0];
         this.numberingEnabled = numberingEnabled;
     }
 
@@ -46,7 +47,7 @@ public class CollapsingSectionsConfiguration implements Serializable {
     }
 
     public CollapsingSectionNote[] getSections() {
-        return sections;
+        return sections != null ? Arrays.copyOf(sections, sections.length) : new CollapsingSectionNote[0];
     }
     
     public SectionDefinition[] getSectionDefinitions() {

--- a/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionsConfiguration.java
+++ b/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionsConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2013 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2013 Oleg Nenashev, Synopsys Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,7 @@ import java.util.ArrayList;
 
 /**
  * Provides a serializable instance of collapsing sections global configs. 
- * @author Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * @author Oleg Nenashev
  * @since 1.4.1
  */
 public class CollapsingSectionsConfiguration implements Serializable {

--- a/src/test/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionAnnotatorTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionAnnotatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2013 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2013 Oleg Nenashev, Synopsys Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,7 @@ import org.jvnet.hudson.test.Bug;
 
 /**
  * Tests {@linl CollapsingSectionAnnotator}
- * @author Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * @author Oleg Nenashev
  * @since 1.4.1
  */
 public class CollapsingSectionAnnotatorTest {


### PR DESCRIPTION
I cannot longer maintain Java6-only plugins, hence I decided to migrate the plugin to the new parent POM with Java 7+ support
- [x] - New core baseline is 1.532.x, because previous versions have conflict with org.sonatype.sisu:sisu-guice
- [x] - FindBugs fixes (also fixes [JENKINS-30690](https://issues.jenkins-ci.org/browse/JENKINS-30690))
- [x] - Fixed my affiliation in order to fix Javadoc failures

@reviewbybees @kuisathaverat
