### PR TITLE
initially start collapsed

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionAnnotator.java
+++ b/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionAnnotator.java
@@ -92,7 +92,7 @@ public class CollapsingSectionAnnotator extends ConsoleAnnotator<Object> {
     
     private void pushSection(MarkupText text, Matcher m, SectionDefinition section) {
         numberingStack.peek().increment();  
-        text.addMarkup(0, "<div class=\"collapseHeader\">" + getCurrentLevelPrefix() + Util.escape(section.getSectionDisplayName(m)) + "<div class=\"collapseAction\"><p onClick=\"doToggle(this)\">Hide Details</p></div></div><div class=\"expanded\">");        
+        text.addMarkup(0, "<div class=\"collapseHeader\">" + getCurrentLevelPrefix() + Util.escape(section.getSectionDisplayName(m)) + "<div class=\"collapseAction\"><p onClick=\"doToggle(this)\">Hide Details</p></div></div><div class=\"collapsed\">");        
         numberingStack.add(new StackLevel());
         currentSections.push(section);
     }


### PR DESCRIPTION
I'd assume that this plugin should hide all the gory details of long console outputs. 
So my assumption would be that the sections started collapsed.