### PR TITLE
Added support for collapsing sections V3

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionAnnotator.java
+++ b/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionAnnotator.java
@@ -92,7 +92,7 @@ public class CollapsingSectionAnnotator extends ConsoleAnnotator<Object> {
     
     private void pushSection(MarkupText text, Matcher m, SectionDefinition section) {
         numberingStack.peek().increment();  
-        text.addMarkup(0, "<div class=\"collapseHeader\">" + getCurrentLevelPrefix() + Util.escape(section.getSectionDisplayName(m)) + "<div class=\"collapseAction\"><p onClick=\"doToggle(this)\">Hide Details</p></div></div><div class=\"expanded\">");        
+        text.addMarkup(0, "<div class=\"collapseHeader\">" + getCurrentLevelPrefix() + Util.escape(section.getSectionDisplayName(m)) + "<div class=\"collapseAction\"><p onClick=\"doToggle(this)\">" + ((section.getCollapseSection()) ? "Show DetailsA" : "Hide DetailsA") +"</p></div></div><div class=\"" + ((section.getCollapseSection()) ? "collapsed" : "expanded") + "\">");
         numberingStack.add(new StackLevel());
         currentSections.push(section);
     }

--- a/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionAnnotator.java
+++ b/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionAnnotator.java
@@ -92,7 +92,7 @@ public class CollapsingSectionAnnotator extends ConsoleAnnotator<Object> {
     
     private void pushSection(MarkupText text, Matcher m, SectionDefinition section) {
         numberingStack.peek().increment();  
-        text.addMarkup(0, "<div class=\"collapseHeader\">" + getCurrentLevelPrefix() + Util.escape(section.getSectionDisplayName(m)) + "<div class=\"collapseAction\"><p onClick=\"doToggle(this)\">" + ((section.getCollapseSection()) ? "Show DetailsA" : "Hide DetailsA") +"</p></div></div><div class=\"" + ((section.getCollapseSection()) ? "collapsed" : "expanded") + "\">");
+        text.addMarkup(0, "<div class=\"collapseHeader\">" + getCurrentLevelPrefix() + Util.escape(section.getSectionDisplayName(m)) + "<div class=\"collapseAction\"><p onClick=\"doToggle(this)\">" + ((section.isCollapseSection()) ? "Show Details" : "Hide Details") +"</p></div></div><div class=\"" + ((section.isCollapseSection()) ? "collapsed" : "expanded") + "\">");
         numberingStack.add(new StackLevel());
         currentSections.push(section);
     }

--- a/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote.java
+++ b/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote.java
@@ -54,11 +54,7 @@ public class CollapsingSectionNote extends ConsoleNote {
     }
 
     public CollapsingSectionNote(String sectionDisplayName, String sectionStartPattern, String sectionEndPattern, boolean collapseOnlyOneLevel) {
-        this.sectionDisplayName = sectionDisplayName;
-        this.sectionStartPattern = sectionStartPattern;
-        this.sectionEndPattern = sectionEndPattern;
-        this.collapseOnlyOneLevel = collapseOnlyOneLevel;
-        this.collapseSection = false;
+        this(sectionDisplayName, sectionStartPattern, sectionEndPattern, collapseOnlyOneLevel, false);
     }
 
     public String getSectionDisplayName() {
@@ -73,9 +69,10 @@ public class CollapsingSectionNote extends ConsoleNote {
         return sectionEndPattern;
     }
 
-    public boolean getCollapseSection() {
+    public boolean isCollapseSection() {
         return collapseSection;
     }
+
     public boolean isCollapseOnlyOneLevel() {
         return collapseOnlyOneLevel;
     }

--- a/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote.java
+++ b/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote.java
@@ -42,13 +42,23 @@ public class CollapsingSectionNote extends ConsoleNote {
     private String sectionStartPattern;
     private String sectionEndPattern;
     private boolean collapseOnlyOneLevel;
-    
+    private boolean collapseSection;
+
     @DataBoundConstructor
+    public CollapsingSectionNote(String sectionDisplayName, String sectionStartPattern, String sectionEndPattern, boolean collapseOnlyOneLevel, boolean collapseSection) {
+        this.sectionDisplayName = sectionDisplayName;
+        this.sectionStartPattern = sectionStartPattern;
+        this.sectionEndPattern = sectionEndPattern;
+        this.collapseOnlyOneLevel = collapseOnlyOneLevel;
+        this.collapseSection = collapseSection;
+    }
+
     public CollapsingSectionNote(String sectionDisplayName, String sectionStartPattern, String sectionEndPattern, boolean collapseOnlyOneLevel) {
         this.sectionDisplayName = sectionDisplayName;
         this.sectionStartPattern = sectionStartPattern;
         this.sectionEndPattern = sectionEndPattern;
         this.collapseOnlyOneLevel = collapseOnlyOneLevel;
+        this.collapseSection = false;
     }
 
     public String getSectionDisplayName() {
@@ -63,14 +73,17 @@ public class CollapsingSectionNote extends ConsoleNote {
         return sectionEndPattern;
     }
 
+    public boolean getCollapseSection() {
+        return collapseSection;
+    }
     public boolean isCollapseOnlyOneLevel() {
         return collapseOnlyOneLevel;
     }
-    
+
     public SectionDefinition getDefinition() {
-        return new SectionDefinition(sectionDisplayName, sectionStartPattern, sectionEndPattern, collapseOnlyOneLevel);
+        return new SectionDefinition(sectionDisplayName, sectionStartPattern, sectionEndPattern, collapseOnlyOneLevel, collapseSection);
     }
-    
+
     @Override
     public ConsoleAnnotator annotate(Object context, MarkupText text, int charPos) {
         return null;

--- a/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/SectionDefinition.java
+++ b/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/SectionDefinition.java
@@ -45,6 +45,10 @@ public class SectionDefinition implements Serializable {
         this(sectionName, sectionStartPattern, sectionEndPattern, false, false);
     }
 
+    public SectionDefinition(String sectionName, String sectionStartPattern, String sectionEndPattern, boolean collapseOnlyOneLevel) {
+        this(sectionName, sectionStartPattern, sectionEndPattern, collapseOnlyOneLevel, false);
+    }
+
     public SectionDefinition(String sectionName, String sectionStartPattern, String sectionEndPattern, boolean collapseOnlyOneLevel, boolean collapseSection) {
         name = sectionName;
         start = Pattern.compile(sectionStartPattern);
@@ -81,7 +85,7 @@ public class SectionDefinition implements Serializable {
     public Pattern getSectionEndPattern() {
         return end;
     }
-    public boolean getCollapseSection() {
+    public boolean isCollapseSection() {
         return collapseSection;
     }
     public boolean isCollapseOnlyOneLevel() {

--- a/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/SectionDefinition.java
+++ b/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/SectionDefinition.java
@@ -36,19 +36,21 @@ public class SectionDefinition implements Serializable {
     private Pattern start;
     private Pattern end;
     private boolean collapseOnlyOneLevel;
+    private boolean collapseSection;
 
-    /** 
+    /**
      * @deprecated Use version with sections collapsing instead
-     */ 
+     */
     public SectionDefinition(String sectionName, String sectionStartPattern, String sectionEndPattern) {
-        this(sectionName, sectionStartPattern, sectionEndPattern, false);
+        this(sectionName, sectionStartPattern, sectionEndPattern, false, false);
     }
-    
-    public SectionDefinition(String sectionName, String sectionStartPattern, String sectionEndPattern, boolean collapseOnlyOneLevel) {
+
+    public SectionDefinition(String sectionName, String sectionStartPattern, String sectionEndPattern, boolean collapseOnlyOneLevel, boolean collapseSection) {
         name = sectionName;
         start = Pattern.compile(sectionStartPattern);
         end = Pattern.compile(sectionEndPattern);
         this.collapseOnlyOneLevel = collapseOnlyOneLevel;
+        this.collapseSection = collapseSection;
     }
 
     public String getSectionDisplayName() {
@@ -79,7 +81,9 @@ public class SectionDefinition implements Serializable {
     public Pattern getSectionEndPattern() {
         return end;
     }
-
+    public boolean getCollapseSection() {
+        return collapseSection;
+    }
     public boolean isCollapseOnlyOneLevel() {
         return collapseOnlyOneLevel;
     }

--- a/src/main/resources/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote/global.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote/global.jelly
@@ -46,7 +46,7 @@ THE SOFTWARE.
                 <f:checkbox title="${%Collapse only one level per ending string}" checked="${instance.collapseOnlyOneLevel}"/>
             </f:entry>
             <f:entry title="${%Collapse Sections}" field="collapseSection">
-                <f:checkbox title="${%Show the section collapsed}" checked="${instance.collapseSection}"/>
+                <f:checkbox title="${%Collapse Sections by default}" checked="${instance.collapseSection}"/>
             </f:entry>
           <f:entry title="">
             <div align="right">

--- a/src/main/resources/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote/global.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote/global.jelly
@@ -45,6 +45,9 @@ THE SOFTWARE.
             <f:entry title="${%One-per-line ending}" field="collapseOnlyOneLevel">
                 <f:checkbox title="${%Collapse only one level per ending string}" checked="${instance.collapseOnlyOneLevel}"/>
             </f:entry>
+            <f:entry title="${%Collapse Sections}" field="collapseSection">
+                <f:checkbox title="${%Show the section collapsed}" checked="${instance.collapseSection}"/>
+            </f:entry>
           <f:entry title="">
             <div align="right">
               <f:repeatableDeleteButton value="Delete ${descriptor.displayName}"/>

--- a/src/main/resources/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote/help-collapseSection.html
+++ b/src/main/resources/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote/help-collapseSection.html
@@ -1,0 +1,5 @@
+<div>
+    By default (false), plugin will show the section expanded.
+    <br/>
+    This option allows the section to be shown collapsed initially.
+</div>


### PR DESCRIPTION
This patch adds a new configuration entry to change this setting for every section entry.
To not damage existing configurations, the new entry is off by default.
V2: Added a second constructor for backward compatibility.
V3: incorperate changes from the last review cycle
- Add the missing constructor
- Renamed the access method
- Improved the description text
