### PR TITLE
Update the Jenkins core requirement to 2.150.3, use the latest Plugin POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.30</version>
+        <version>3.54</version>
     </parent>
 
     <artifactId>collapsing-console-sections</artifactId>
@@ -36,8 +36,8 @@ THE SOFTWARE.
     <packaging>hpi</packaging>
     
     <properties>
-        <jenkins.version>1.609.3</jenkins.version>
-        <java.level>6</java.level>
+        <jenkins.version>2.150.3</jenkins.version>
+        <java.level>8</java.level>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.license>mit</project.license>
     </properties>


### PR DESCRIPTION
When trying to build the project under Java 11 I encountered
a failure with javadoc as well as other oddities.

* Use latest parent pom (3.54)
* Bump Jenkins version to some recent LTS (2.164.3)
* Target java.level 8, the minimal version supported by Jenkins