### PR TITLE
Reduce the priority of the Collapsing Console Sections annotator so that it runs after other annotators and takes data injected by them into account

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionAnnotator.java
+++ b/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionAnnotator.java
@@ -101,8 +101,10 @@ public class CollapsingSectionAnnotator extends ConsoleAnnotator<Object> {
     }
     
     private void pushSection(@Nonnull MarkupText text, @Nonnull Matcher m, @Nonnull SectionDefinition section) {
-        numberingStack.peek().increment();  
-        text.addMarkup(0, "<div class=\"section\" data-level=\""+getCurrentLevelPrefix()+"\"><div class=\"collapseHeader\">" + getCurrentLevelPrefix() + Util.escape(section.getSectionDisplayName(m)) + "<div class=\"collapseAction\"><p onClick=\"doToggle(this)\">" + ((section.isCollapseSection()) ? "Show Details" : "Hide Details") +"</p></div></div><div class=\"" + ((section.isCollapseSection()) ? "collapsed" : "expanded") + "\">");
+        numberingStack.peek().increment();
+        // Add as end tag, which will be inserted prior to tags added by other
+        // console notes such as the timestamper plugin.
+        text.addMarkup(0, 0, "", "<div class=\"section\" data-level=\""+getCurrentLevelPrefix()+"\"><div class=\"collapseHeader\">" + getCurrentLevelPrefix() + Util.escape(section.getSectionDisplayName(m)) + "<div class=\"collapseAction\"><p onClick=\"doToggle(this)\">" + ((section.isCollapseSection()) ? "Show Details" : "Hide Details") +"</p></div></div><div class=\"" + ((section.isCollapseSection()) ? "collapsed" : "expanded") + "\">");
         numberingStack.add(new StackLevel());
         currentSections.push(section);
     }

--- a/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionAnnotatorFactory.java
+++ b/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionAnnotatorFactory.java
@@ -32,12 +32,12 @@ import jenkins.model.Jenkins;
  *
  * @author dty
  */
-@Extension
+@Extension(ordinal = -500) // Act after timestamper plugins and others.
 public class CollapsingSectionAnnotatorFactory extends ConsoleAnnotatorFactory {
     @Override
     public ConsoleAnnotator newInstance(Object context) {
         final Jenkins jenkins = Jenkins.getActiveInstance();
-        
+
         CollapsingSectionNote.DescriptorImpl descr = jenkins.getDescriptorByType(CollapsingSectionNote.DescriptorImpl.class);
         if (descr.getSectionDefinitions().length == 0) {
             return null;


### PR DESCRIPTION
Better interaction with others ConsoleAnnotator

When one also uses the ansicolor and/or timestamper plugins, the
ConsoleAnnotator extension points have the same ordinal value (the
default of 0). The annotation are thus processed in whatever order the
plugins got registered.

This patch fixes compatibility with both ansicolor and the timestamper
plugins.

ansicolor
=========

With the ansicolor plugin, it will notice the collapsible section HTML
and wraps it in an HTML comment. The HTML output ends up being broken.

Given a message that starts with a green INFO:

    \033[32mINFO\033[0m:message

And a collapsible section start set to: `.*message.*`

When the section is processes before ansicolor, the output looks like:

    <!--<div class="section ...>\033[32m-->
    <span style="color: #00CD00;">INFO<!-- \033[0m --></span>:message

Which is broken. The reason is the ansicolor plugin magically comments
out the HTML element, considering it is a `<span>` it might have
generated.

The fix I have found is to have the collapsible section ConsoleAnnotator
to act last, or at least after the ansicolor plugin which also has the
default ordinal of 0. Setting CollapsingSectionAnnotatorFactory to an
ordinal of -500 does the trick.

timestamper
===========

The timestamp is inserted before the HTML for the collapsible section
and the output looks like:

    00:00:00 [myjob] $ /bin/sh -xe /tmp/jenkins1234.sh
    00:00:01
    ---------------------------------
         Section title
    |Hide Details|
    ---------------------------------
    INFO:message
    00:00:02 INFO:next message

That happens regardless of the order in which the ConsoleAnnotator
extension points are processed. I have found that in the timestamper
plugin, its html is inserted as an end tag:

    text.addMarkup(0, 0, "", html);

See for details:
http://hudson.361315.n4.nabble.com/TimeStamper-interferes-with-ant-target-highlighting-td2399725.html
https://github.com/jenkinsci/timestamper-plugin/commit/8211416d572e91a7baa5487c92c70dace0680547

That somehow causes the timestamp to always appear before the section
HTML. Or to say it otherwise, the timestamper wraps the other tags.
The timestamp thus appears out of the collapsible section.

For the ansicolor compatibility, the collapsible section
ConsoleAnnotator is made to have a lower ordinal it is thus processed
after the timestamper. This patch change the markup to be inserted as an
end tag, exactly like the timestamper plugin does. The collapsible
section will thus wrap the timestamp as well:

    00:00:00 [myjob] $ /bin/sh -xe /tmp/jenkins1234.sh
    ---------------------------------
         Section title
    |Hide Details|
    ---------------------------------
    00:00:01 INFO:message
    00:00:02 INFO:next message

Note
====

One can inspect the ConsoleAnnotator order in the Jenkins script console
using:

    i=1
    Jenkins.instance.getExtensionList(
        hudson.console.ConsoleAnnotatorFactory.class
    ).each() {
        println("${i++} ${it}")
    }

Example:

    1 hudson.plugins.timestamper.annotator.TimestampAnnotatorFactory3@4182bbd6
    2 hudson.console.UrlAnnotator@e50060d
    3 hudson.plugins.ansicolor.ColorConsoleAnnotator$Factory@7978884d
    4 hudson.plugins.timestamper.pipeline.GlobalAnnotator$Factory@7ee9e785
    5 org.jvnet.hudson.plugins.collapsingconsolesections.CollapsingSectionAnnotatorFactory@2ae1bf85

Bug: https://phabricator.wikimedia.org/T236222
Bug: T236222
