### PR TITLE
added switch to disallow nesting of same sections

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionAnnotator.java
+++ b/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionAnnotator.java
@@ -23,16 +23,18 @@
  */
 package org.jvnet.hudson.plugins.collapsingconsolesections;
 
-import hudson.MarkupText;
-import hudson.Util;
-import hudson.console.ConsoleAnnotator;
-import hudson.model.Run;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Stack;
 import java.util.regex.Matcher;
+
 import javax.annotation.Nonnull;
+
+import hudson.MarkupText;
+import hudson.Util;
+import hudson.console.ConsoleAnnotator;
+import hudson.model.Run;
 
 public class CollapsingSectionAnnotator extends ConsoleAnnotator<Object> {
     
@@ -62,8 +64,8 @@ public class CollapsingSectionAnnotator extends ConsoleAnnotator<Object> {
             return null;
         }
         
+        SectionDefinition currentSection = currentSections.peek();
         while (!currentSections.empty()) {
-            SectionDefinition currentSection = currentSections.peek();
             if (currentSection.getSectionEndPattern().matcher(text.getText().trim()).matches()) {
                 popSection(text);
                 if (currentSection.isCollapseOnlyOneLevel()) {
@@ -72,9 +74,13 @@ public class CollapsingSectionAnnotator extends ConsoleAnnotator<Object> {
             } else {
                 break;
             }
+            currentSection = currentSections.peek();
         }
 
         for (SectionDefinition section : sections) {
+            if(currentSection.getSectionDisplayName().equals(section.getSectionDisplayName()) && !section.isAllowNesting()) {
+                continue;
+            }
             Matcher m = section.getSectionStartPattern().matcher(text.getText().trim());
             if (m.matches()) {
                 pushSection(text, m, section);

--- a/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote.java
+++ b/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote.java
@@ -23,6 +23,21 @@
  */
 package org.jvnet.hudson.plugins.collapsingconsolesections;
 
+import java.lang.reflect.Array;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+import net.sf.json.JSONObject;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.MarkupText;
@@ -30,17 +45,6 @@ import hudson.console.ConsoleAnnotationDescriptor;
 import hudson.console.ConsoleAnnotator;
 import hudson.console.ConsoleNote;
 import hudson.util.FormValidation;
-import java.lang.reflect.Array;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import net.sf.json.JSONObject;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
 
 /**
  *
@@ -56,19 +60,21 @@ public class CollapsingSectionNote extends ConsoleNote {
     private String sectionEndPattern;
     private boolean collapseOnlyOneLevel;
     private boolean collapseSection;
+    private boolean allowNesting;
 
     @DataBoundConstructor
-    public CollapsingSectionNote(@Nonnull String sectionDisplayName, @Nonnull String sectionStartPattern, @Nonnull String sectionEndPattern, boolean collapseOnlyOneLevel, boolean collapseSection) {
+    public CollapsingSectionNote(@Nonnull String sectionDisplayName, @Nonnull String sectionStartPattern, @Nonnull String sectionEndPattern, boolean collapseOnlyOneLevel, boolean collapseSection, boolean allowNesting) {
         this.sectionDisplayName = sectionDisplayName;
         this.sectionStartPattern = sectionStartPattern;
         this.sectionEndPattern = sectionEndPattern;
         this.collapseOnlyOneLevel = collapseOnlyOneLevel;
         this.collapseSection = collapseSection;
+        this.allowNesting = allowNesting;
     }
 
     @Deprecated
     public CollapsingSectionNote(String sectionDisplayName, String sectionStartPattern, String sectionEndPattern, boolean collapseOnlyOneLevel) {
-        this(sectionDisplayName, sectionStartPattern, sectionEndPattern, collapseOnlyOneLevel, false);
+        this(sectionDisplayName, sectionStartPattern, sectionEndPattern, collapseOnlyOneLevel, false, false);
     }
 
     @Nonnull
@@ -101,7 +107,7 @@ public class CollapsingSectionNote extends ConsoleNote {
 
     @Nonnull
     public SectionDefinition getDefinition() {
-        return new SectionDefinition(sectionDisplayName, sectionStartPattern, sectionEndPattern, collapseOnlyOneLevel, collapseSection);
+        return new SectionDefinition(sectionDisplayName, sectionStartPattern, sectionEndPattern, collapseOnlyOneLevel, collapseSection, allowNesting);
     }
 
     @Override

--- a/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/SectionDefinition.java
+++ b/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/SectionDefinition.java
@@ -27,6 +27,7 @@ import java.io.Serializable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+
 import javax.annotation.Nonnull;
 
 /**
@@ -39,13 +40,14 @@ public class SectionDefinition implements Serializable {
     private Pattern end;
     private boolean collapseOnlyOneLevel;
     private boolean collapseSection;
+    private boolean allowNesting;
 
     /**
      * @deprecated Use {@link #SectionDefinition(java.lang.String, java.lang.String, java.lang.String, boolean, boolean)} instead.
      */
     @Deprecated
     public SectionDefinition(String sectionName, String sectionStartPattern, String sectionEndPattern) {
-        this(sectionName, sectionStartPattern, sectionEndPattern, false, false);
+        this(sectionName, sectionStartPattern, sectionEndPattern, false, false, false);
     }
 
     /**
@@ -53,7 +55,7 @@ public class SectionDefinition implements Serializable {
      */
     @Deprecated
     public SectionDefinition(String sectionName, String sectionStartPattern, String sectionEndPattern, boolean collapseOnlyOneLevel) {
-        this(sectionName, sectionStartPattern, sectionEndPattern, collapseOnlyOneLevel, false);
+        this(sectionName, sectionStartPattern, sectionEndPattern, collapseOnlyOneLevel, false, false);
     }
 
     /**
@@ -65,12 +67,13 @@ public class SectionDefinition implements Serializable {
      * @param collapseSection If {@code true}, the section should be collapsed by default
      * @throws PatternSyntaxException One of the patterns is invalid
      */
-    public SectionDefinition(@Nonnull String sectionName, @Nonnull String sectionStartPattern, @Nonnull String sectionEndPattern, boolean collapseOnlyOneLevel, boolean collapseSection) throws PatternSyntaxException {
+    public SectionDefinition(@Nonnull String sectionName, @Nonnull String sectionStartPattern, @Nonnull String sectionEndPattern, boolean collapseOnlyOneLevel, boolean collapseSection, boolean allowNesting) throws PatternSyntaxException {
         name = sectionName;
         start = Pattern.compile(sectionStartPattern);
         end = Pattern.compile(sectionEndPattern);
         this.collapseOnlyOneLevel = collapseOnlyOneLevel;
         this.collapseSection = collapseSection;
+        this.allowNesting = allowNesting;
     }
 
     @Nonnull
@@ -110,5 +113,8 @@ public class SectionDefinition implements Serializable {
     }
     public boolean isCollapseOnlyOneLevel() {
         return collapseOnlyOneLevel;
+    }
+    public boolean isAllowNesting() {
+        return allowNesting;
     }
 }

--- a/src/main/resources/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote/global.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote/global.jelly
@@ -48,6 +48,9 @@ THE SOFTWARE.
             <f:entry title="${%Collapse Sections}" field="collapseSection">
                 <f:checkbox title="${%Collapse Sections by default}" checked="${instance.collapseSection}"/>
             </f:entry>
+            <f:entry title="${%Allow Nesting}" field="allowNesting">
+                <f:checkbox title="${%Allow Nesting Sections}" checked="${instance.allowNesting}"/>
+            </f:entry>
           <f:entry title="">
             <div align="right">
               <f:repeatableDeleteButton value="Delete ${descriptor.displayName}"/>

--- a/src/main/resources/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote/help-allowNesting.html
+++ b/src/main/resources/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote/help-allowNesting.html
@@ -1,0 +1,3 @@
+<div>
+    Determines whether nesting of the same section should be allowed.
+</div>


### PR DESCRIPTION
In case you want to collapse all download logs of maven, it is needed to disallow nesting of the same section. Otherwise, you will have a lot nesting in case of the following configuration:

![grafik](https://user-images.githubusercontent.com/1427255/84440391-31b13880-ac3a-11ea-9eaf-0efea4d93046.png)

and a quite odd UI as of the outline generated:

![grafik](https://user-images.githubusercontent.com/1427255/84440451-4ee60700-ac3a-11ea-9e4d-99f4b1afdf55.png)
