### PR TITLE
[INFRA-1310] Update Jquery plugin dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@ THE SOFTWARE.
   	<dependency>
   		<groupId>org.jenkins-ci.plugins</groupId>
   		<artifactId>jquery</artifactId>
-  		<version>1.11.2-0</version>
+  		<version>1.11.2-1</version>
   	</dependency>
   </dependencies>
 </project>  


### PR DESCRIPTION
This is primarily to fix the build due to an unbound transitive dependencies added by stapler-adjunct-jquery.
