### PR TITLE
[JENKINS-70906] Remove PrototypeJS Ajax.Updater

### DIFF
--- a/src/main/resources/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote/script.js
+++ b/src/main/resources/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote/script.js
@@ -76,15 +76,21 @@ function doToggle(o)
 
         if (!loading) {
             loading = true;
-            var u = new Ajax.Updater(document.getElementById("side-panel"),
-                rootURL+"/descriptor/org.jvnet.hudson.plugins.collapsingconsolesections.CollapsingSectionNote/outline",
-                {insertion: Insertion.Bottom, onComplete: function() {
-                    if (!u.success())   return; // we can't us onSuccess because that kicks in before onComplete
-                    outline = document.getElementById("console-section-body");
-                    initFloatingSection();
-                    loading = false;
-                    queue.each(handle);
-                }});
+            fetch(
+                rootURL+"/descriptor/org.jvnet.hudson.plugins.collapsingconsolesections.CollapsingSectionNote/outline"
+            ).then(
+                (resp) => {
+                    resp.text().then( (responseText) => {
+                        const sidePanel = document.getElementById("side-panel");
+                        sidePanel.insertAdjacentHTML("beforeend", responseText);
+
+                        outline = document.getElementById("console-section-body");
+                        initFloatingSection();
+                        loading = false;
+                        queue.forEach(handle);
+                    })
+                }
+            );
         }
         return true;
     }


### PR DESCRIPTION
The table of content in the sidebar would not show in the sidebar due to the removal of PrototypeJS in Jenkins 2.426.1. Replace the old Ajax.Updater call with a modern fetch().

I have confirmed the fix using `mvn hpi:run` with Jenkins 2.426.1 (and bumping the parent pom to 4.77).