### PR TITLE
Drop dependency on jQuery 1.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,14 +90,6 @@ THE SOFTWARE.
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-    
-  <dependencies>
-  	<dependency>
-  		<groupId>org.jenkins-ci.plugins</groupId>
-  		<artifactId>jquery</artifactId>
-  		<version>1.12.4-1</version>
-  	</dependency>
-  </dependencies>
 </project>  
   
 


### PR DESCRIPTION
This plugin currently depends on jQuery 1.x, which does not work with Content-Security-Policy (CSP) headers. For this plugin to survive in the post-CSP Jenkins world, it cannot use jQuery 1.x. Here we write all jQuery 1.x uses in plain JavaScript to allow this plugin to continue in the post-CSP Jenkins world.

### Testing done

Manually added a job with nested console sections and verified by stepping through the browser debugger that the code worked the same way as before.