### PR TITLE
Remove Internet Explorer 8 compatibility code

### DIFF
--- a/src/main/resources/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote/script.js
+++ b/src/main/resources/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote/script.js
@@ -2,22 +2,12 @@
 // eslint-disable-next-line no-unused-vars
 function doToggle(o) {
     var section = o.parentNode.parentNode;
-    if (section.nextElementSibling) {
-        if (section.nextElementSibling.className === "collapsed") {
-            section.nextElementSibling.className = "expanded";
-            o.innerHTML = "Hide Details";
-        } else {
-            section.nextElementSibling.className = "collapsed";
-            o.innerHTML = "Show Details";
-        }
+    if (section.nextElementSibling.className === "collapsed") {
+        section.nextElementSibling.className = "expanded";
+        o.innerHTML = "Hide Details";
     } else {
-        if (section.nextSibling.className === "collapsed") {
-            section.nextSibling.className = "expanded";
-            o.innerHTML = "Hide Details";
-        } else {
-            section.nextSibling.className = "collapsed";
-            o.innerHTML = "Show Details";
-        }
+        section.nextElementSibling.className = "collapsed";
+        o.innerHTML = "Show Details";
     }
 }
 


### PR DESCRIPTION
Internet Explorer 8 did not support Element.nextElementSibling(). When it is not existing, logic was copy pasted to use Element.nextSibling() instead.

Given Internet Explorer 8 was released in March 2009 and has long been replaced, I don't think there is any need to keep that code around.

Revert "[FIXED JENKINS-15568] - Collapsing sections correctly appear in IE"
This reverts commit 1d6f8b94557f2416c14c148192c8bcd18890f7d1.

**Note:** [JENKINS-15568](https://issues.jenkins.io/browse/JENKINS-15568) refers to Internet Explorer 9 and https://caniuse.com/mdn-api_element_nextelementsibling claims version 9 supported `Element.nextElementSibling()`.

I have tested it with `mvn hpi:run` and Firefox 128.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira: https://issues.jenkins.io/browse/JENKINS-15568
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
