### PR TITLE
Fix jumping from sidebar link to a collapsed section

### DIFF
--- a/src/main/resources/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote/script.js
+++ b/src/main/resources/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionNote/script.js
@@ -29,11 +29,9 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     function generateOutlineSection(sectionElt) {
+        // give section a unique ID for the target link
         var id = "console-section-" + (iota++);
-        // add target link in output log
-        var targetLink = document.createElement("a");
-        targetLink.name = id;
-        sectionElt.prepend(targetLink);
+        sectionElt.id = id;
 
         // create outline element
         var collapseHeader = sectionElt.querySelector("summary.collapseHeader");
@@ -41,6 +39,7 @@ document.addEventListener("DOMContentLoaded", function () {
         var elt = document.createElement("li");
         listElt.appendChild(elt);
 
+        // add target link in the outline
         var link = document.createElement("a");
         link.href = "#" + id;
         link.textContent = justtext(collapseHeader);


### PR DESCRIPTION
Follows-up https://github.com/jenkinsci/collapsing-console-sections-plugin/pull/35, which broke this.

Before that, the server output this:

```html
<div class=section ..>
  <div class=collapseHeader> .. <p onClick="doToggle(this)">..</p></div>
  <div class="collapsed">
  …
  </div>
</div>
```

And, script.js would prepend the `<a name>` destination to each `div.section` element, which worked because the part that was toggled is the div.collapsed/div.expanded child, not the section itself.

After that, the server output this:

```html
<details class=collapsingSection>
  <summary class=collapseHeader>..</summary>
  ..
  <div>
  </div>
</details>
```

Where `<details>` is entirely hidden by the browser, except for the `<summary>` child. Any content outside of the `summary` child is thus part of the content that is toggled. The collapsible element is thus `<details>`, not the `<div>`.

And, script.js still prepended `<a name>` to the same re-used `sectionElt` variable, now pointing at `details.collapsingSection`, thus making it in some strange itself toggleable, as 0x0px content *above* the summary and toggle button.

Fix this by removing the element and simply setting an ID on the `<details>` element itself.

### Testing done

* On https://integration.wikimedia.org/ci/job/wmf-quibble-core-vendor-mysql-php81/3287/console#console-section-0, the link "Logs generated by test" in the outline broken in Firefox and Safari. (It works in Chrome.)
* Find the `<details>` element in the devtools inspector, and removing `<a name>`, and setting an ID on the details instead.
* The same link now works.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

/cc @hashar 