### PR TITLE
Ban JUnit 4 imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@ THE SOFTWARE.
         <jenkins.version>${jenkins.baseline}.1</jenkins.version>
         <node.version>20.18.0</node.version>
         <npm.version>10.9.0</npm.version>
+        <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
         <maven.test.failure.ignore>false</maven.test.failure.ignore>
         <frontend.testFailureIgnore>${maven.test.failure.ignore}</frontend.testFailureIgnore>
     </properties>


### PR DESCRIPTION
### Ban JUnit 4 imports

To prevent regressions when adding new tests, https://github.com/jenkinsci/plugin-pom/pull/1178 introduced a new flag that enables a Maven Enforcer rule banning `org.junit.*` imports while allowing `org.junit.jupiter.*`.

With this change, the build will fail if any `org.junit.*` imports are introduced.

### Testing done

None. Rely on `ci.jenkins.io`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed