### PR TITLE
Handle backlashes and dollar signs in captured groups

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/SectionDefinition.java
+++ b/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/SectionDefinition.java
@@ -86,7 +86,10 @@ public class SectionDefinition implements Serializable {
             for (int i = 0; i <= m.groupCount(); i++) {
                 final String group = m.group(i);
                 if (group != null) {
-                    result = result.replaceAll("\\{" + i + "\\}", group);
+                    result = result.replaceAll(
+                        "\\{" + i + "\\}",
+                        Matcher.quoteReplacement(group)
+                    );
                 } else {
                     result = result.replaceAll("\\{" + i + "\\}", "");
                 }

--- a/src/test/java/org/jvnet/hudson/plugins/collapsingconsolesections/SectionDefinitionTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/collapsingconsolesections/SectionDefinitionTest.java
@@ -61,6 +61,16 @@ class SectionDefinitionTest {
         assertEquals("Section Heading https svn.dev.java.net https", def.getSectionDisplayName(m));
     }
 
+    /**
+     * @see <a href="https://phabricator.wikimedia.org/T420347">https://phabricator.wikimedia.org/T420347</a>
+     */
+    @Test
+    void testGroupCaptureHandlesSpecialCharacters() {
+        SectionDefinition def = new SectionDefinition("Command: {1}", "Spawning (.*)", "", false, false);
+        Matcher m = def.getSectionStartPattern().matcher("Spawning cd $FOO && git grep \\-");
+        assertEquals("Command: cd $FOO && git grep \\-", def.getSectionDisplayName(m));
+    }
+
     @Test
     void testMavenPluginDefinition() {
         testMavenMojoPlugin("[INFO] --- maven-jar-plugin:2.3.1:jar (default-jar) @ sardine ---", "jar:jar");


### PR DESCRIPTION
With a start section defined with a capturing group such as:

    ^>>>: Start: (.*)

And a section name referring to the captured group using curly braces such as: `{1}`

Then, when the group contains a backslash (\) or a dollar sign ($):

    >>> Start: cp --verbose $WORKSPACE/src/LocalSettings.php $LOG_DIR

It throws:

    java.lang.IllegalArgumentException: Illegal group reference

The reason is `String.replaceAll(regex, replacement)` threats backslashes and dollars in `replacement` specially. The `$` is used to refer to a captured group.

Quote replacement strings in the group.

Bug: https://phabricator.wikimedia.org/T420347