### PR TITLE
Remove usages of Commons Lang 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@ THE SOFTWARE.
         <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
         <maven.test.failure.ignore>false</maven.test.failure.ignore>
         <frontend.testFailureIgnore>${maven.test.failure.ignore}</frontend.testFailureIgnore>
+        <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
     </properties>
 
     <name>Jenkins Collapsing Console Sections Plugin</name>

--- a/src/test/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionAnnotatorTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionAnnotatorTest.java
@@ -23,7 +23,8 @@
  */
 package org.jvnet.hudson.plugins.collapsingconsolesections;
 
-import org.apache.commons.lang.SerializationUtils;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 
@@ -36,7 +37,7 @@ class CollapsingSectionAnnotatorTest {
 
     @Test
     @Issue("JENKINS-20304")
-    void testSerialization() {
+    void testSerialization() throws Exception {
         // Prepare data
         CollapsingSectionsConfiguration config = new CollapsingSectionsConfiguration(
             new CollapsingSectionNote[] {
@@ -47,6 +48,8 @@ class CollapsingSectionAnnotatorTest {
         CollapsingSectionAnnotator annotator = new CollapsingSectionAnnotator(config);
 
         // Try to serialize
-        SerializationUtils.serialize(annotator);
+        try (ObjectOutputStream out = new ObjectOutputStream(new ByteArrayOutputStream())) {
+            out.writeObject(annotator);
+        }
     }
 }


### PR DESCRIPTION
No need to depend on a third-party library here when the Java Platform provides this
functionality natively.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

## What's changed

- `CollapsingSectionAnnotatorTest` was the only Commons Lang consumer, using
  `SerializationUtils.serialize(annotator)` to check the annotator is serializable. That is now a
  plain `ObjectOutputStream.writeObject`, which is exactly what `SerializationUtils` does — so no
  dependency is needed for one test assertion.
- Enabled the `ban-commons-lang-2` enforcer rule to prevent regressions.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.

The `ban-commons-lang-2` enforcer rule is enabled in this PR, so the build fails if an
`org.apache.commons.lang.*` import comes back.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact @timja.
